### PR TITLE
Create .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+/.gitattributes  export-ignore
+/.gitignore      export-ignore
+


### PR DESCRIPTION
This will prevent the `.gitattributes` and `.gitignore` file from being downloaded when this package is downloaded with Composer. Files (and folders) like `phpunit.xml`, `tests/`, etc. should also be added to this list to prevent the download size from being unnecessarily large.