### PR TITLE
Remove defaults from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "decahedron/laravel-app-events",
     "description": "Manage application-wide events for SOAs with Google Cloud PubSub",
-    "type": "library",
     "license": "MIT",
     "authors": [
         {
@@ -9,7 +8,6 @@
             "email": "leo@decahedron.io"
         }
     ],
-    "minimum-stability": "stable",
     "require": {
         "google/cloud": "^0.88.0",
         "illuminate/config": "5.7.*",


### PR DESCRIPTION
- `type`'s default is `library`: https://getcomposer.org/doc/04-schema.md#type
- `minimum-stability`'s default is `stable`: https://getcomposer.org/doc/04-schema.md#minimum-stability

This means these 2 lines can be removed from our `composer.json`.