### PR TITLE
End the autoload path with a '/'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Decahedron\\AppEvents\\": "src"
+            "Decahedron\\AppEvents\\": "src/"
         }
     },
     "extra": {


### PR DESCRIPTION
It's good practice to do it this way. Nearly everyone ends the autoload paths with a `/`, and [it's documented that way](https://getcomposer.org/doc/01-basic-usage.md#autoloading). This library should follow convention 🙂 